### PR TITLE
feat(flux): reconcile HRs with valuesFrom without kustomizeconfig

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
@@ -10,5 +10,5 @@ configMapGenerator:
   - name: cert-manager-helm-values
     files:
       - values.yaml=./values.yaml
-configurations:
-  - kustomizeconfig.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/cert-manager/cert-manager/app/kustomizeconfig.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/kustomizeconfig.yaml
@@ -1,7 +1,0 @@
----
-nameReference:
-  - kind: ConfigMap
-    version: v1
-    fieldSpecs:
-      - path: spec/valuesFrom/name
-        kind: HelmRelease

--- a/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -9,5 +9,5 @@ configMapGenerator:
   - name: external-secrets-helm-values
     files:
       - values.yaml=./values.yaml
-configurations:
-  - kustomizeconfig.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/external-secrets/external-secrets/app/kustomizeconfig.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/kustomizeconfig.yaml
@@ -1,7 +1,0 @@
----
-nameReference:
-  - kind: ConfigMap
-    version: v1
-    fieldSpecs:
-      - path: spec/valuesFrom/name
-        kind: HelmRelease

--- a/kubernetes/apps/flux-system/flux-operator/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/kustomization.yaml
@@ -9,5 +9,5 @@ configMapGenerator:
   - name: flux-operator-helm-values
     files:
       - values.yaml=./values.yaml
-configurations:
-  - kustomizeconfig.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/flux-system/flux-operator/app/kustomizeconfig.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/kustomizeconfig.yaml
@@ -1,7 +1,0 @@
----
-nameReference:
-  - kind: ConfigMap
-    version: v1
-    fieldSpecs:
-      - path: spec/valuesFrom/name
-        kind: HelmRelease

--- a/kubernetes/apps/flux-system/flux-operator/instance/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/instance/kustomization.yaml
@@ -11,5 +11,5 @@ configMapGenerator:
   - name: flux-instance-helm-values
     files:
       - values.yaml=./values.yaml
-configurations:
-  - kustomizeconfig.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/flux-system/flux-operator/instance/kustomizeconfig.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/instance/kustomizeconfig.yaml
@@ -1,7 +1,0 @@
----
-nameReference:
-  - kind: ConfigMap
-    version: v1
-    fieldSpecs:
-      - path: spec/valuesFrom/name
-        kind: HelmRelease

--- a/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
@@ -10,5 +10,5 @@ configMapGenerator:
   - name: cilium-values
     files:
       - values.yaml=./values.yaml
-configurations:
-  - kustomizeconfig.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/kube-system/cilium/app/kustomizeconfig.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/kustomizeconfig.yaml
@@ -1,7 +1,0 @@
----
-nameReference:
-  - kind: ConfigMap
-    version: v1
-    fieldSpecs:
-      - path: spec/valuesFrom/name
-        kind: HelmRelease

--- a/kubernetes/apps/kube-system/coredns/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/kustomization.yaml
@@ -9,5 +9,5 @@ configMapGenerator:
   - name: coredns-values
     files:
       - values.yaml=./values.yaml
-configurations:
-  - kustomizeconfig.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/kube-system/coredns/app/kustomizeconfig.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/kustomizeconfig.yaml
@@ -1,7 +1,0 @@
----
-nameReference:
-  - kind: ConfigMap
-    version: v1
-    fieldSpecs:
-      - path: spec/valuesFrom/name
-        kind: HelmRelease


### PR DESCRIPTION
Upcoming feature from Flux 2.7.0 is that it will be able to reconcile HRs with `valueFrom` when an annotation is set on the secret/configmap. This removes the need to have a kustomizeconfig patch.

https://github.com/fluxcd/flux2/issues/5446